### PR TITLE
Replace 'source' with '.' in sh script.

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -75,8 +75,8 @@ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.
 
 # copy .local.bash to system, enable on reboot
 cp ~/code/go/src/github.com/siggy/ledmesh/.local.bash ~/
-source ~/.local.bash
-echo "[[ -s ${HOME}/.local.bash ]] && source ${HOME}/.local.bash" >> ~/.bashrc
+. ~/.local.bash
+echo "[[ -s ${HOME}/.local.bash ]] && . ${HOME}/.local.bash" >> ~/.bashrc
 
 
 


### PR DESCRIPTION
The bootstrap script is run using /bin/sh which, unlike /bin/bash, doesn't have the source command.