### PR TITLE
Fix go/python i/o

### DIFF
--- a/test_bash_io.sh
+++ b/test_bash_io.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while read INPUT
+  do echo "Hello, $INPUT."
+done

--- a/test_go_py_io.py
+++ b/test_go_py_io.py
@@ -12,9 +12,6 @@ import sys
 for line in sys.stdin:
     if not line.strip() or line.strip().startswith('#'):
         continue
-    data = base64.b64decode(line.strip())    
-    
-    print(data)    
+    data = base64.b64decode(line.strip())
 
-
-    
+    print(data.decode("utf-8"))


### PR DESCRIPTION
Modify `test_python_io.go` to send a newline along with base64 encoded
message. This informs the python script to read a line of text.

Also tweak the base64 message to represet a string-encoded integer
rather than byte encoded, for better human readability on the command
line:
[]byte{8} vs. []byte("8")

Also hard-code `python3 -u`, to force unbuffered i/o. If python3 is not
always available, we'll need to revisit this.

Modify `test_go_py_io.py` to return the message string-encoded rather
than bytes.

Also introduce a `test_bash_io.sh` test script that echo messages from
stdin back to stdout. Useful for swapping out `test_go_py_io.py` in the
Go script.

Signed-off-by: Andrew Seigner <andrew@sig.gy>